### PR TITLE
Support guzzle promises ^2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "rize/uri-template": "~0.3",
         "google/auth": "^1.18",
         "guzzlehttp/guzzle": "^5.3|^6.5.7|^7.4.4",
-        "guzzlehttp/promises": "^1.3",
+        "guzzlehttp/promises": "^1.3|^2.0",
         "guzzlehttp/psr7": "^1.7|^2.0",
         "monolog/monolog": "^1.1|^2.0|^3.0",
         "psr/http-message": "^1.0"


### PR DESCRIPTION
Fixes support guzzle/promises 2.0
```
google/cloud-core[v1.43.0, ..., v1.51.2] require guzzlehttp/promises ^1.3 -> found guzzlehttp/promises[1.3.0, ..., 1.5.3] but the package is fixed to 2.0.0 (lock file version) by a partial update and that version does not match. Make sure you list it as an argument for the update command.
```