### PR TITLE
feat: Add a default retryListener to the RequestWrapper class

### DIFF
--- a/src/RequestWrapper.php
+++ b/src/RequestWrapper.php
@@ -169,7 +169,7 @@ class RequestWrapper
         $this->restOptions = $config['restOptions'];
         $this->shouldSignRequest = $config['shouldSignRequest'];
         $this->retryFunction = $config['restRetryFunction'] ?: $this->getRetryFunction();
-        $this->retryListener = $config['restRetryListener'] ;
+        $this->retryListener = $config['restRetryListener'];
         $this->delayFunction = $config['restDelayFunction'] ?: function ($delay) {
             usleep($delay);
         };
@@ -372,7 +372,7 @@ class RequestWrapper
      */
     private function addAuthHeaders(RequestInterface $request, FetchAuthTokenInterface $fetcher)
     {
-        $backoff = new ExponentialBackoff($this->retries, $this->getRetryFunction());
+        $backoff = new ExponentialBackoff($this->retries, $this->getRetryFunction(), $this->retryListener);
 
         try {
             return $backoff->execute(

--- a/src/RequestWrapper.php
+++ b/src/RequestWrapper.php
@@ -84,6 +84,12 @@ class RequestWrapper
     private $retryFunction;
 
     /**
+     * @var callable|null Lets the user listen for retries and
+     * modify the next retry arguments
+     */
+    private $retryListener;
+
+    /**
      * @var callable Executes a delay.
      */
     private $delayFunction;
@@ -136,6 +142,8 @@ class RequestWrapper
      *           determining how long to wait between attempts to retry. Function
      *           signature should match: `function (int $attempt) : int`.
      *     @type string $universeDomain The expected universe of the credentials. Defaults to "googleapis.com".
+     *     @type callable $restRetryListener A function to run custom logic between retries. This function can modify
+     *           the next server call arguments for the next retry.
      * }
      */
     public function __construct(array $config = [])
@@ -151,6 +159,7 @@ class RequestWrapper
             'componentVersion' => null,
             'restRetryFunction' => null,
             'restDelayFunction' => null,
+            'restRetryListener' => null,
             'restCalcDelayFunction' => null,
             'universeDomain' => GetUniverseDomainInterface::DEFAULT_UNIVERSE_DOMAIN,
         ];
@@ -160,6 +169,7 @@ class RequestWrapper
         $this->restOptions = $config['restOptions'];
         $this->shouldSignRequest = $config['shouldSignRequest'];
         $this->retryFunction = $config['restRetryFunction'] ?: $this->getRetryFunction();
+        $this->retryListener = $config['restRetryListener'] ;
         $this->delayFunction = $config['restDelayFunction'] ?: function ($delay) {
             usleep($delay);
         };
@@ -485,7 +495,7 @@ class RequestWrapper
                 : $this->retryFunction,
             'retryListener' => isset($options['restRetryListener'])
                 ? $options['restRetryListener']
-                : null,
+                : $this->retryListener,
             'delayFunction' => isset($options['restDelayFunction'])
                 ? $options['restDelayFunction']
                 : $this->delayFunction,

--- a/tests/Unit/RequestWrapperTest.php
+++ b/tests/Unit/RequestWrapperTest.php
@@ -40,6 +40,7 @@ use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
+use ReflectionClass;
 
 /**
  * @group core
@@ -857,6 +858,27 @@ class RequestWrapperTest extends TestCase
         // send a fake request
         $requestWrapper->send(new Request('GET', 'http://www.example.com'));
         $this->assertTrue($called);
+    }
+
+    public function testRetryListenerOnConstructor()
+    {
+        $listener = function ($_, int $__, array &$___) {
+            return;
+        };
+        $wrapper = new RequestWrapper([
+            'restRetryListener' => $listener
+        ]);
+
+        $reflectionClass = new ReflectionClass($wrapper);
+        $property = $reflectionClass->getProperty('retryListener');
+        $property->setAccessible(true);
+
+        $this->assertNotEmpty($property->getValue($wrapper), 'The retryListener property should be set.');
+        $this->assertEquals(
+            $listener,
+            $property->getValue($wrapper),
+            'The retryListener should be the same as the one passed via options.'
+        );
     }
 
     public function provideCheckUniverseDomainPasses()


### PR DESCRIPTION
We are currently adding logging support to a few of our hand written libraries. The logger does not have access to the `retryAttempt` and being able to add a custom `retryListener` from the libraries that need to configure it instead of passing this method for every single `send` call is a much more cleaner approach.